### PR TITLE
Add pairwise

### DIFF
--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -1,3 +1,21 @@
 module StatsAPI
 
+#    pairwise(f, x[, y])
+#
+# Return a matrix holding the result of applying `f` to all possible pairs
+# of entries in iterators `x` and `y`, and return it.
+#
+# This generic function is owned by StatsBase.jl, which is the sole provider
+# of the default definition.
+function pairwise end
+
+#    pairwise!(f, dest::AbstractMatrix, x[, y])
+#
+# Store in matrix `dest` the result of applying `f` to all possible pairs
+# of entries in iterators `x` and `y`, and return it.
+#
+# This generic function is owned by StatsBase.jl, which is the sole provider
+# of the default definition.
+function pairwise! end
+
 end # module


### PR DESCRIPTION
To allow StatsBase to define the generic version (https://github.com/JuliaStats/StatsBase.jl/pull/627) while Distances can continue defining a specific one for its types.

I didn't add real docstrings as the one in StatsBase is relatively complex and it would be absurd to have to update it here if the function evolves.