### PR TITLE
add nobs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsAPI"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 authors = ["Milan Bouchet-Valat <nalimilan@club.fr"]
-version = "1.0.0"
+version = "1.1.0"
 
 [compat]
 julia = "1"

--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -18,4 +18,11 @@ function pairwise end
 # of the default definition.
 function pairwise! end
 
+"""
+    nobs(dataset)
+
+Return the number of observations in the dataset. 
+"""
+function nobs end
+
 end # module


### PR DESCRIPTION
Over at https://github.com/JuliaML/LearnBase.jl
We are using `LearnBase.getobs` and `StatsBase.nobs` to create a generic api for datasets. It would be nice to remove the dependence from StatsBase there and rely on StatsAPI instead.

Notice that the [docstring in StatsBase](https://github.com/JuliaStats/StatsBase.jl/blob/baf223c0fc76c62d3db538d14751aa3397cb9245/src/statmodels.jl#L106
) denotes that the method is meant to query a model instead of a dataset, so I add a docstring here to expand the interpretation
