### PR TITLE
move statsmodels.jl types and function stubs from StatsBase

### DIFF
--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -1,14 +1,14 @@
 module StatsAPI
 
-include("regressionmodel.jl")
 include("statisticalmodel.jl")
+include("regressionmodel.jl")
 
 """
     params(model)
 
 Return all parameters of a model.
 """
-params(model) = error("params is not defined for $(typeof(model))")
+function params end
 
 function params! end
 

--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -1,5 +1,17 @@
 module StatsAPI
 
+include("regressionmodel.jl")
+include("statisticalmodel.jl")
+
+"""
+    params(model)
+
+Return all parameters of a model.
+"""
+params(model) = error("params is not defined for $(typeof(model))")
+
+function params! end
+
 #    pairwise(f, x[, y])
 #
 # Return a matrix holding the result of applying `f` to all possible pairs

--- a/src/regressionmodel.jl
+++ b/src/regressionmodel.jl
@@ -46,7 +46,6 @@ function modelmatrix end
 Return `X'X` where `X` is the model matrix of `model`.
 This function will return a pre-computed matrix stored in `model` if possible.
 """
-function crossmodelmatrix end
 crossmodelmatrix(model::RegressionModel) = (x = modelmatrix(model); Symmetric(x' * x))
 
 """

--- a/src/regressionmodel.jl
+++ b/src/regressionmodel.jl
@@ -10,35 +10,35 @@ abstract type RegressionModel <: StatisticalModel end
 
 Return the fitted values of the model.
 """
-fitted(model::RegressionModel) = error("fitted is not defined for $(typeof(model)).")
+function fitted end
 
 """
     response(model::RegressionModel)
 
 Return the model response (a.k.a. the dependent variable).
 """
-response(model::RegressionModel) = error("response is not defined for $(typeof(model)).")
+function response end
 
 """
     responsename(model::RegressionModel)
 
 Return the name of the model response (a.k.a. the dependent variable).
 """
-responsename(model::RegressionModel) = error("responsename is not defined for $(typeof(model)).")
+function responsename end
 
 """
     meanresponse(model::RegressionModel)
 
 Return the mean of the response.
 """
-meanresponse(model::RegressionModel) = error("meanresponse is not defined for $(typeof(model)).")
+function meanresponse end
 
 """
     modelmatrix(model::RegressionModel)
 
 Return the model matrix (a.k.a. the design matrix).
 """
-modelmatrix(model::RegressionModel) = error("modelmatrix is not defined for $(typeof(model)).")
+function modelmatrix end
 
 """
     crossmodelmatrix(model::RegressionModel)
@@ -46,6 +46,7 @@ modelmatrix(model::RegressionModel) = error("modelmatrix is not defined for $(ty
 Return `X'X` where `X` is the model matrix of `model`.
 This function will return a pre-computed matrix stored in `model` if possible.
 """
+function crossmodelmatrix end
 crossmodelmatrix(model::RegressionModel) = (x = modelmatrix(model); Symmetric(x' * x))
 
 """
@@ -53,7 +54,7 @@ crossmodelmatrix(model::RegressionModel) = (x = modelmatrix(model); Symmetric(x'
 
 Return the diagonal of the projection matrix of the model.
 """
-leverage(model::RegressionModel) = error("leverage is not defined for $(typeof(model)).")
+function leverage end
 
 """
     cooksdistance(model::RegressionModel)
@@ -62,14 +63,14 @@ Compute [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance)
 for each observation in linear model `model`, giving an estimate of the influence
 of each data point.
 """
-cooksdistance(model::RegressionModel) = error("cooksdistance is not defined for $(typeof(model)).")
+function cooksdistance end
 
 """
     residuals(model::RegressionModel)
 
 Return the residuals of the model.
 """
-residuals(model::RegressionModel) = error("residuals is not defined for $(typeof(model)).")
+function residuals end
 
 """
     predict(model::RegressionModel, [newX])
@@ -80,8 +81,6 @@ it would generally be a `DataFrame` with the same variable names as the original
 """
 function predict end
 
-predict(model::RegressionModel) = error("predict is not defined for $(typeof(model)).")
-
 """
     predict!
 
@@ -89,11 +88,9 @@ In-place version of [`predict`](@ref).
 """
 function predict! end
 
-predict!(model::RegressionModel) = error("predict! is not defined for $(typeof(model)).")
-
 """
     dof_residual(model::RegressionModel)
 
 Return the residual degrees of freedom of the model.
 """
-dof_residual(model::RegressionModel) = error("dof_residual is not defined for $(typeof(model)).")
+function dof_residual end

--- a/src/regressionmodel.jl
+++ b/src/regressionmodel.jl
@@ -1,0 +1,99 @@
+"""
+    RegressionModel <: StatisticalModel
+
+Abstract supertype for all regression models.
+"""
+abstract type RegressionModel <: StatisticalModel end
+
+"""
+    fitted(model::RegressionModel)
+
+Return the fitted values of the model.
+"""
+fitted(model::RegressionModel) = error("fitted is not defined for $(typeof(model)).")
+
+"""
+    response(model::RegressionModel)
+
+Return the model response (a.k.a. the dependent variable).
+"""
+response(model::RegressionModel) = error("response is not defined for $(typeof(model)).")
+
+"""
+    responsename(model::RegressionModel)
+
+Return the name of the model response (a.k.a. the dependent variable).
+"""
+responsename(model::RegressionModel) = error("responsename is not defined for $(typeof(model)).")
+
+"""
+    meanresponse(model::RegressionModel)
+
+Return the mean of the response.
+"""
+meanresponse(model::RegressionModel) = error("meanresponse is not defined for $(typeof(model)).")
+
+"""
+    modelmatrix(model::RegressionModel)
+
+Return the model matrix (a.k.a. the design matrix).
+"""
+modelmatrix(model::RegressionModel) = error("modelmatrix is not defined for $(typeof(model)).")
+
+"""
+    crossmodelmatrix(model::RegressionModel)
+
+Return `X'X` where `X` is the model matrix of `model`.
+This function will return a pre-computed matrix stored in `model` if possible.
+"""
+crossmodelmatrix(model::RegressionModel) = (x = modelmatrix(model); Symmetric(x' * x))
+
+"""
+    leverage(model::RegressionModel)
+
+Return the diagonal of the projection matrix of the model.
+"""
+leverage(model::RegressionModel) = error("leverage is not defined for $(typeof(model)).")
+
+"""
+    cooksdistance(model::RegressionModel)
+
+Compute [Cook's distance](https://en.wikipedia.org/wiki/Cook%27s_distance)
+for each observation in linear model `model`, giving an estimate of the influence
+of each data point.
+"""
+cooksdistance(model::RegressionModel) = error("cooksdistance is not defined for $(typeof(model)).")
+
+"""
+    residuals(model::RegressionModel)
+
+Return the residuals of the model.
+"""
+residuals(model::RegressionModel) = error("residuals is not defined for $(typeof(model)).")
+
+"""
+    predict(model::RegressionModel, [newX])
+
+Form the predicted response of `model`. An object with new covariate values `newX` can be supplied,
+which should have the same type and structure as that used to fit `model`; e.g. for a GLM
+it would generally be a `DataFrame` with the same variable names as the original predictors.
+"""
+function predict end
+
+predict(model::RegressionModel) = error("predict is not defined for $(typeof(model)).")
+
+"""
+    predict!
+
+In-place version of [`predict`](@ref).
+"""
+function predict! end
+
+predict!(model::RegressionModel) = error("predict! is not defined for $(typeof(model)).")
+
+"""
+    dof_residual(model::RegressionModel)
+
+Return the residual degrees of freedom of the model.
+"""
+dof_residual(model::RegressionModel) = error("dof_residual is not defined for $(typeof(model)).")

--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -185,10 +185,38 @@ Fit a statistical model in-place.
 """
 fit!(model::StatisticalModel, args...) = error("fit! is not defined for $(typeof(model)).")
 
-# Defined and documented for `StatisticalModel` in StatsBase
-function aic end
-function aicc end
-function bic end
+"""
+    aic(model::StatisticalModel)
+
+Akaike's Information Criterion, defined as ``-2 \\log L + 2k``, with ``L`` the likelihood
+of the model, and `k` its number of consumed degrees of freedom
+(as returned by [`dof`](@ref)).
+"""
+aic(model::StatisticalModel) = -2loglikelihood(model) + 2dof(model)
+
+"""
+    aicc(model::StatisticalModel)
+
+Corrected Akaike's Information Criterion for small sample sizes (Hurvich and Tsai 1989),
+defined as ``-2 \\log L + 2k + 2k(k-1)/(n-k-1)``, with ``L`` the likelihood of the model,
+``k`` its number of consumed degrees of freedom (as returned by [`dof`](@ref)),
+and ``n`` the number of observations (as returned by [`nobs`](@ref)).
+"""
+function aicc(model::StatisticalModel)
+    k = dof(model)
+    n = nobs(model)
+    -2loglikelihood(model) + 2k + 2k*(k+1)/(n-k-1)
+end
+
+"""
+    bic(model::StatisticalModel)
+
+Bayesian Information Criterion, defined as ``-2 \\log L + k \\log n``, with ``L``
+the likelihood of the model,  ``k`` its number of consumed degrees of freedom
+(as returned by [`dof`](@ref)), and ``n`` the number of observations
+(as returned by [`nobs`](@ref)).
+"""
+bic(model::StatisticalModel) = -2loglikelihood(model) + dof(model)*log(nobs(model))
 
 """
     r2(model::StatisticalModel)

--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -1,0 +1,218 @@
+"""
+    StatisticalModel
+
+Abstract supertype for all statistical models.
+"""
+abstract type StatisticalModel end
+
+"""
+    coef(model::StatisticalModel)
+
+Return the coefficients of the model.
+"""
+coef(model::StatisticalModel) = error("coef is not defined for $(typeof(model)).")
+
+"""
+    coefnames(model::StatisticalModel)
+
+Return the names of the coefficients.
+"""
+coefnames(model::StatisticalModel) = error("coefnames is not defined for $(typeof(model)).")
+
+"""
+    coeftable(model::StatisticalModel; level::Real=0.95)
+
+Return a table with coefficients and related statistics of the model.
+`level` determines the level for confidence intervals (by default, 95%).
+
+The returned `CoefTable` object implements the
+[Tables.jl](https://github.com/JuliaData/Tables.jl/) interface, and can be
+converted e.g. to a `DataFrame` via `using DataFrames; DataFrame(coeftable(model))`.
+"""
+coeftable(model::StatisticalModel) = error("coeftable is not defined for $(typeof(model)).")
+
+"""
+    confint(model::StatisticalModel; level::Real=0.95)
+
+Compute confidence intervals for coefficients, with confidence level `level` (by default 95%).
+"""
+confint(model::StatisticalModel) = error("confint is not defined for $(typeof(model)).")
+
+"""
+    deviance(model::StatisticalModel)
+
+Return the deviance of the model relative to a reference, which is usually when applicable
+the saturated model. It is equal, *up to a constant*, to ``-2 \\log L``, with ``L``
+the likelihood of the model.
+"""
+deviance(model::StatisticalModel) = error("deviance is not defined for $(typeof(model)).")
+
+"""
+    islinear(model::StatisticalModel)
+
+Indicate whether the model is linear.
+"""
+islinear(model::StatisticalModel) = error("islinear is not defined for $(typeof(model)).")
+
+"""
+    nulldeviance(model::StatisticalModel)
+
+Return the deviance of the null model, that is the one including only the intercept.
+"""
+nulldeviance(model::StatisticalModel) =
+    error("nulldeviance is not defined for $(typeof(model)).")
+
+"""
+    loglikelihood(model::StatisticalModel)
+
+Return the log-likelihood of the model.
+"""
+loglikelihood(model::StatisticalModel) =
+    error("loglikelihood is not defined for $(typeof(model)).")
+
+"""
+    loglikelihood(model::StatisticalModel)
+
+Return the log-likelihood of the null model corresponding to `model`.
+This is usually the model containing only the intercept.
+"""
+nullloglikelihood(model::StatisticalModel) =
+    error("nullloglikelihood is not defined for $(typeof(model)).")
+
+"""
+    loglikelihood(model::StatisticalModel, ::Colon)
+
+Return a vector of each observation's contribution to the log-likelihood of the model.
+In other words, this is the vector of the pointwise log-likelihood contributions.
+
+In general, `sum(loglikehood(model, :)) == loglikelihood(model)`.
+"""
+loglikelihood(model::StatisticalModel, ::Colon) =
+    error("loglikelihood(model::StatisticalModel, ::Colon) is not defined for $(typeof(model)).")
+
+"""
+    loglikelihood(model::StatisticalModel, observation)
+
+Return the contribution of `observation` to the log-likelihood of `model`.
+"""
+loglikelihood(model::StatisticalModel, observation) =
+    error("loglikelihood(model::StatisticalModel, observation) is not defined for $(typeof(model)).")
+
+"""
+    score(model::StatisticalModel)
+
+Return the score of the model, that is the gradient of the
+log-likelihood with respect to the coefficients.
+"""
+score(model::StatisticalModel) = error("score is not defined for $(typeof(model)).")
+
+"""
+    nobs(model::StatisticalModel)
+
+Return the number of independent observations on which the model was fitted. Be careful
+when using this information, as the definition of an independent observation may vary
+depending on the model, on the format used to pass the data, on the sampling plan
+(if specified), etc.
+"""
+nobs(model::StatisticalModel) = error("nobs is not defined for $(typeof(model)).")
+
+"""
+    dof(model::StatisticalModel)
+
+Return the number of degrees of freedom consumed in the model, including
+when applicable the intercept and the distribution's dispersion parameter.
+"""
+dof(model::StatisticalModel) = error("dof is not defined for $(typeof(model)).")
+
+"""
+    mss(model::StatisticalModel)
+
+Return the model sum of squares.
+"""
+mss(model::StatisticalModel) = error("mss is not defined for $(typeof(model)).")
+
+"""
+    rss(model::StatisticalModel)
+
+Return the residual sum of squares of the model.
+"""
+rss(model::StatisticalModel) = error("rss is not defined for $(typeof(model)).")
+
+"""
+    informationmatrix(model::StatisticalModel; expected::Bool = true)
+
+Return the information matrix of the model. By default the Fisher information matrix
+is returned, while the observed information matrix can be requested with `expected = false`.
+"""
+informationmatrix(model::StatisticalModel; expected::Bool=true) =
+    error("informationmatrix is not defined for $(typeof(model)).")
+
+"""
+    stderror(model::StatisticalModel)
+
+Return the standard errors for the coefficients of the model.
+"""
+stderror(model::StatisticalModel) = sqrt.(diag(vcov(model)))
+
+"""
+    vcov(model::StatisticalModel)
+
+Return the variance-covariance matrix for the coefficients of the model.
+"""
+vcov(model::StatisticalModel) = error("vcov is not defined for $(typeof(model)).")
+
+"""
+    weights(model::StatisticalModel)
+
+Return the weights used in the model.
+"""
+weights(model::StatisticalModel) = error("weights is not defined for $(typeof(model)).")
+
+"""
+    isfitted(model::StatisticalModel)
+
+Indicate whether the model has been fitted.
+"""
+isfitted(model::StatisticalModel) = error("isfitted is not defined for $(typeof(model)).")
+
+"""
+Fit a statistical model.
+"""
+fit(model::StatisticalModel, args...) = error("fit is not defined for $(typeof(model)).")
+
+"""
+Fit a statistical model in-place.
+"""
+fit!(model::StatisticalModel, args...) = error("fit! is not defined for $(typeof(model)).")
+
+# Defined and documented for `StatisticalModel` in StatsBase
+function aic end
+function aicc end
+function bic end
+
+"""
+    r2(model::StatisticalModel)
+    r²(model::StatisticalModel)
+
+Coefficient of determination (R-squared).
+
+For a linear model, the R² is defined as ``ESS/TSS``, with ``ESS`` the explained sum of squares
+and ``TSS`` the total sum of squares.
+"""
+r2(model::StatisticalModel) = error("r2/r² is not defined for $(typeof(model)).")
+
+const r² = r2
+
+"""
+    adjr2(model::StatisticalModel)
+    adjr²(model::StatisticalModel)
+
+Adjusted coefficient of determination (adjusted R-squared).
+
+For linear models, the adjusted R² is defined as ``1 - (1 - (1-R^2)(n-1)/(n-p))``, with ``R^2``
+the coefficient of determination, ``n`` the number of observations, and ``p`` the number of
+coefficients (including the intercept). This definition is generally known as the Wherry Formula I.
+"""
+adjr2(model::StatisticalModel) = error("adjr2 is not defined for $(typeof(model)).")
+
+const adjr² = adjr2

--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -63,35 +63,28 @@ function nulldeviance end
 
 """
     loglikelihood(model::StatisticalModel)
+    loglikelihood(model::StatisticalModel, observation)
 
 Return the log-likelihood of the model.
-"""
-function loglikelihood end
 
-"""
-    loglikelihood(model::StatisticalModel)
+With an `observation` argument, return the contribution of `observation` to the
+log-likelihood of `model`.
 
-Return the log-likelihood of the null model corresponding to `model`.
-This is usually the model containing only the intercept.
-"""
-function nullloglikelihood end
-
-"""
-    loglikelihood(model::StatisticalModel, ::Colon)
-
-Return a vector of each observation's contribution to the log-likelihood of the model.
-In other words, this is the vector of the pointwise log-likelihood contributions.
+If `observation` is a `Colon`, return a vector of each observation's contribution
+to the log-likelihood of the model. In other words, this is the vector of the
+pointwise log-likelihood contributions.
 
 In general, `sum(loglikehood(model, :)) == loglikelihood(model)`.
 """
 function loglikelihood end
 
 """
-    loglikelihood(model::StatisticalModel, observation)
+    nullloglikelihood(model::StatisticalModel)
 
-Return the contribution of `observation` to the log-likelihood of `model`.
+Return the log-likelihood of the null model corresponding to `model`.
+This is usually the model containing only the intercept.
 """
-function loglikelihood end
+function nullloglikelihood end
 
 """
     score(model::StatisticalModel)
@@ -186,7 +179,6 @@ Akaike's Information Criterion, defined as ``-2 \\log L + 2k``, with ``L`` the l
 of the model, and `k` its number of consumed degrees of freedom
 (as returned by [`dof`](@ref)).
 """
-function aic end
 aic(model::StatisticalModel) = -2loglikelihood(model) + 2dof(model)
 
 """
@@ -197,7 +189,6 @@ defined as ``-2 \\log L + 2k + 2k(k-1)/(n-k-1)``, with ``L`` the likelihood of t
 ``k`` its number of consumed degrees of freedom (as returned by [`dof`](@ref)),
 and ``n`` the number of observations (as returned by [`nobs`](@ref)).
 """
-function aic end
 function aicc(model::StatisticalModel)
     k = dof(model)
     n = nobs(model)
@@ -212,7 +203,6 @@ the likelihood of the model,  ``k`` its number of consumed degrees of freedom
 (as returned by [`dof`](@ref)), and ``n`` the number of observations
 (as returned by [`nobs`](@ref)).
 """
-function bic end
 bic(model::StatisticalModel) = -2loglikelihood(model) + dof(model)*log(nobs(model))
 
 """

--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -10,14 +10,14 @@ abstract type StatisticalModel end
 
 Return the coefficients of the model.
 """
-coef(model::StatisticalModel) = error("coef is not defined for $(typeof(model)).")
+function coef end
 
 """
     coefnames(model::StatisticalModel)
 
 Return the names of the coefficients.
 """
-coefnames(model::StatisticalModel) = error("coefnames is not defined for $(typeof(model)).")
+function coefnames end
 
 """
     coeftable(model::StatisticalModel; level::Real=0.95)
@@ -29,14 +29,14 @@ The returned `CoefTable` object implements the
 [Tables.jl](https://github.com/JuliaData/Tables.jl/) interface, and can be
 converted e.g. to a `DataFrame` via `using DataFrames; DataFrame(coeftable(model))`.
 """
-coeftable(model::StatisticalModel) = error("coeftable is not defined for $(typeof(model)).")
+function coeftable end
 
 """
     confint(model::StatisticalModel; level::Real=0.95)
 
 Compute confidence intervals for coefficients, with confidence level `level` (by default 95%).
 """
-confint(model::StatisticalModel) = error("confint is not defined for $(typeof(model)).")
+function confint end
 
 """
     deviance(model::StatisticalModel)
@@ -45,30 +45,28 @@ Return the deviance of the model relative to a reference, which is usually when 
 the saturated model. It is equal, *up to a constant*, to ``-2 \\log L``, with ``L``
 the likelihood of the model.
 """
-deviance(model::StatisticalModel) = error("deviance is not defined for $(typeof(model)).")
+function deviance end
 
 """
     islinear(model::StatisticalModel)
 
 Indicate whether the model is linear.
 """
-islinear(model::StatisticalModel) = error("islinear is not defined for $(typeof(model)).")
+function islinear end
 
 """
     nulldeviance(model::StatisticalModel)
 
 Return the deviance of the null model, that is the one including only the intercept.
 """
-nulldeviance(model::StatisticalModel) =
-    error("nulldeviance is not defined for $(typeof(model)).")
+function nulldeviance end
 
 """
     loglikelihood(model::StatisticalModel)
 
 Return the log-likelihood of the model.
 """
-loglikelihood(model::StatisticalModel) =
-    error("loglikelihood is not defined for $(typeof(model)).")
+function loglikelihood end
 
 """
     loglikelihood(model::StatisticalModel)
@@ -76,8 +74,7 @@ loglikelihood(model::StatisticalModel) =
 Return the log-likelihood of the null model corresponding to `model`.
 This is usually the model containing only the intercept.
 """
-nullloglikelihood(model::StatisticalModel) =
-    error("nullloglikelihood is not defined for $(typeof(model)).")
+function nullloglikelihood end
 
 """
     loglikelihood(model::StatisticalModel, ::Colon)
@@ -87,16 +84,14 @@ In other words, this is the vector of the pointwise log-likelihood contributions
 
 In general, `sum(loglikehood(model, :)) == loglikelihood(model)`.
 """
-loglikelihood(model::StatisticalModel, ::Colon) =
-    error("loglikelihood(model::StatisticalModel, ::Colon) is not defined for $(typeof(model)).")
+function loglikelihood end
 
 """
     loglikelihood(model::StatisticalModel, observation)
 
 Return the contribution of `observation` to the log-likelihood of `model`.
 """
-loglikelihood(model::StatisticalModel, observation) =
-    error("loglikelihood(model::StatisticalModel, observation) is not defined for $(typeof(model)).")
+function loglikelihood end
 
 """
     score(model::StatisticalModel)
@@ -104,7 +99,7 @@ loglikelihood(model::StatisticalModel, observation) =
 Return the score of the model, that is the gradient of the
 log-likelihood with respect to the coefficients.
 """
-score(model::StatisticalModel) = error("score is not defined for $(typeof(model)).")
+function score end
 
 """
     nobs(model::StatisticalModel)
@@ -114,7 +109,7 @@ when using this information, as the definition of an independent observation may
 depending on the model, on the format used to pass the data, on the sampling plan
 (if specified), etc.
 """
-nobs(model::StatisticalModel) = error("nobs is not defined for $(typeof(model)).")
+function nobs end
 
 """
     dof(model::StatisticalModel)
@@ -122,21 +117,21 @@ nobs(model::StatisticalModel) = error("nobs is not defined for $(typeof(model)).
 Return the number of degrees of freedom consumed in the model, including
 when applicable the intercept and the distribution's dispersion parameter.
 """
-dof(model::StatisticalModel) = error("dof is not defined for $(typeof(model)).")
+function dof end
 
 """
     mss(model::StatisticalModel)
 
 Return the model sum of squares.
 """
-mss(model::StatisticalModel) = error("mss is not defined for $(typeof(model)).")
+function mss end
 
 """
     rss(model::StatisticalModel)
 
 Return the residual sum of squares of the model.
 """
-rss(model::StatisticalModel) = error("rss is not defined for $(typeof(model)).")
+function rss end
 
 """
     informationmatrix(model::StatisticalModel; expected::Bool = true)
@@ -144,46 +139,45 @@ rss(model::StatisticalModel) = error("rss is not defined for $(typeof(model)).")
 Return the information matrix of the model. By default the Fisher information matrix
 is returned, while the observed information matrix can be requested with `expected = false`.
 """
-informationmatrix(model::StatisticalModel; expected::Bool=true) =
-    error("informationmatrix is not defined for $(typeof(model)).")
+function informationmatrix end
 
 """
     stderror(model::StatisticalModel)
 
 Return the standard errors for the coefficients of the model.
 """
-stderror(model::StatisticalModel) = sqrt.(diag(vcov(model)))
+function stderror end
 
 """
     vcov(model::StatisticalModel)
 
 Return the variance-covariance matrix for the coefficients of the model.
 """
-vcov(model::StatisticalModel) = error("vcov is not defined for $(typeof(model)).")
+function vcov end
 
 """
     weights(model::StatisticalModel)
 
 Return the weights used in the model.
 """
-weights(model::StatisticalModel) = error("weights is not defined for $(typeof(model)).")
+function weights end
 
 """
     isfitted(model::StatisticalModel)
 
 Indicate whether the model has been fitted.
 """
-isfitted(model::StatisticalModel) = error("isfitted is not defined for $(typeof(model)).")
+function isfitted end
 
 """
 Fit a statistical model.
 """
-fit(model::StatisticalModel, args...) = error("fit is not defined for $(typeof(model)).")
+function fit end
 
 """
 Fit a statistical model in-place.
 """
-fit!(model::StatisticalModel, args...) = error("fit! is not defined for $(typeof(model)).")
+function fit! end
 
 """
     aic(model::StatisticalModel)
@@ -192,6 +186,7 @@ Akaike's Information Criterion, defined as ``-2 \\log L + 2k``, with ``L`` the l
 of the model, and `k` its number of consumed degrees of freedom
 (as returned by [`dof`](@ref)).
 """
+function aic end
 aic(model::StatisticalModel) = -2loglikelihood(model) + 2dof(model)
 
 """
@@ -202,6 +197,7 @@ defined as ``-2 \\log L + 2k + 2k(k-1)/(n-k-1)``, with ``L`` the likelihood of t
 ``k`` its number of consumed degrees of freedom (as returned by [`dof`](@ref)),
 and ``n`` the number of observations (as returned by [`nobs`](@ref)).
 """
+function aic end
 function aicc(model::StatisticalModel)
     k = dof(model)
     n = nobs(model)
@@ -216,6 +212,7 @@ the likelihood of the model,  ``k`` its number of consumed degrees of freedom
 (as returned by [`dof`](@ref)), and ``n`` the number of observations
 (as returned by [`nobs`](@ref)).
 """
+function bic end
 bic(model::StatisticalModel) = -2loglikelihood(model) + dof(model)*log(nobs(model))
 
 """
@@ -227,7 +224,7 @@ Coefficient of determination (R-squared).
 For a linear model, the R² is defined as ``ESS/TSS``, with ``ESS`` the explained sum of squares
 and ``TSS`` the total sum of squares.
 """
-r2(model::StatisticalModel) = error("r2/r² is not defined for $(typeof(model)).")
+function r2 end
 
 const r² = r2
 
@@ -241,6 +238,6 @@ For linear models, the adjusted R² is defined as ``1 - (1 - (1-R^2)(n-1)/(n-p))
 the coefficient of determination, ``n`` the number of observations, and ``p`` the number of
 coefficients (including the intercept). This definition is generally known as the Wherry Formula I.
 """
-adjr2(model::StatisticalModel) = error("adjr2 is not defined for $(typeof(model)).")
+function adjr2 end
 
 const adjr² = adjr2


### PR DESCRIPTION
This PR moves `StatisticalModel` and `RegressionModel` types, and most function stubs from statsmodels.jl in StatsBase to StatsAPI.

- `bic`, `aic` and `aicc` are included here ~as undocumented stubs in statisticalmodels.jl, the implementation and its specific documentation should  probably remain in StatsBase.jl.~ with the full implementation, as its so small and generic
- `params` has been put in the main file as it was not defined for a specific type.


I'm wondering if we should export all of these types and methods? The existing methods were not exported.

See https://github.com/JuliaStats/StatsBase.jl/issues/726