### PR TITLE
Add `summarize` for summary statistics of a model

### DIFF
--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -231,3 +231,10 @@ coefficients (including the intercept). This definition is generally known as th
 function adjr2 end
 
 const adjr² = adjr2
+
+"""
+    summarize(model::StatisticalModel)
+
+Compute summary statistics for the model.
+"""
+function summarize end


### PR DESCRIPTION
I think it would be frequent to have a function that returns the collated statistics of interest for a statistical model, hence providing a `summarize` function to extend would be helpful.