### PR TITLE
Add stderror function that was in StatsBase

### DIFF
--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -134,12 +134,15 @@ is returned, while the observed information matrix can be requested with `expect
 """
 function informationmatrix end
 
+function stderror end
+
 """
     stderror(model::StatisticalModel)
 
 Return the standard errors for the coefficients of the model.
 """
-function stderror end
+stderror(model::StatisticalModel) = sqrt.(diag(vcov(model)))
+
 
 """
     vcov(model::StatisticalModel)


### PR DESCRIPTION
In StatsBase, there was a function that calculated the standard error for a regression in a pretty common way:
```julia
stderror(model::StatisticalModel) = sqrt.(diag(vcov(model)))
```

This pull request just readds that function.

See discussion on [discourse](https://discourse.julialang.org/t/getting-an-error-for-fixedeffectmodels/76498) for an example of a package that needs it.