### PR TITLE
Fix missing fallback definition for `stderror`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsAPI"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 authors = ["Milan Bouchet-Valat <nalimilan@club.fr"]
-version = "1.2.0"
+version = "1.2.1"
 
 [compat]
 julia = "1"

--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -139,7 +139,7 @@ function informationmatrix end
 
 Return the standard errors for the coefficients of the model.
 """
-function stderror end
+stderror(model::StatisticalModel) = sqrt.(diag(vcov(model)))
 
 """
     vcov(model::StatisticalModel)


### PR DESCRIPTION
This definition was present in StatsBase, but not added by https://github.com/JuliaStats/StatsAPI.jl/pull/4, which breaks packages which rely on it (https://discourse.julialang.org/t/fixedeffectmodels-jl-getting-strange-methoderror-on-fresh-install/76505).