### PR TITLE
Import LinearAlgebra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 authors = ["Milan Bouchet-Valat <nalimilan@club.fr"]
 version = "1.2.1"
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [compat]
 julia = "1"
 

--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -1,5 +1,7 @@
 module StatsAPI
 
+using LinearAlgebra
+
 include("statisticalmodel.jl")
 include("regressionmodel.jl")
 


### PR DESCRIPTION
Needed by `stderror` to call `diag`.

Missed by https://github.com/JuliaStats/StatsAPI.jl/pull/9.