### PR TITLE
Add tests for statistical models

### DIFF
--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -255,7 +255,7 @@ function r2(model::StatisticalModel, variant::Symbol)
         dev0 = nulldeviance(model)
         1 - dev/dev0
     else
-        error("variant must be one of $(join(loglikbased, ", ")) or :devianceratio")
+        throw(ArgumentError("variant must be one of $(join(loglikbased, ", ")) or :devianceratio"))
     end
 end
 
@@ -298,7 +298,7 @@ function adjr2(model::StatisticalModel, variant::Symbol)
         dev0 = nulldeviance(model)
         1 - (dev*(n-1))/(dev0*(n-k))
     else
-        error("variant must be one of :McFadden or :devianceratio")
+        throw(ArgumentError("variant must be one of :McFadden or :devianceratio"))
     end
 end
 

--- a/test/regressionmodel.jl
+++ b/test/regressionmodel.jl
@@ -1,0 +1,18 @@
+module TestRegressionModel
+
+using Test, LinearAlgebra, StatsAPI
+using StatsAPI: RegressionModel, crossmodelmatrix
+
+struct MyRegressionModel <: RegressionModel
+end
+
+StatsAPI.modelmatrix(::MyRegressionModel) = [1 2; 3 4]
+
+@testset "TestRegressionModel" begin
+    m = MyRegressionModel()
+
+    @test crossmodelmatrix(m) == [10 14; 14 20]
+    @test crossmodelmatrix(m) isa Symmetric
+end
+
+end # module TestRegressionModel

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test, StatsAPI
 
 @testset "StatsAPI" begin
 
-# Nothing to test currently apart from checking that package can be loaded
+include("regressionmodel.jl")
+include("statisticalmodel.jl")
 
 end # @testset "StatsAPI"

--- a/test/statisticalmodel.jl
+++ b/test/statisticalmodel.jl
@@ -1,0 +1,39 @@
+module TestStatisticalModel
+
+using Test, StatsAPI
+using StatsAPI: StatisticalModel, stderror, aic, aicc, bic, r2, r², adjr2, adjr²
+
+struct MyStatisticalModel <: StatisticalModel
+end
+
+StatsAPI.vcov(::MyStatisticalModel) = [1 2; 3 4]
+StatsAPI.loglikelihood(::MyStatisticalModel) = 3
+StatsAPI.nullloglikelihood(::MyStatisticalModel) = 4
+StatsAPI.deviance(::MyStatisticalModel) = 25
+StatsAPI.nulldeviance(::MyStatisticalModel) = 40
+StatsAPI.dof(::MyStatisticalModel) = 5
+StatsAPI.nobs(::MyStatisticalModel) = 100
+
+@testset "StatisticalModel" begin
+    m = MyStatisticalModel()
+
+    @test stderror(m) == [1, 2]
+    @test aic(m) == 4
+    @test aicc(m) ≈ 4.638297872340425
+    @test bic(m) ≈ 17.02585092994046
+    @test r2(m, :McFadden) ≈ 0.25
+    @test r2(m, :CoxSnell) ≈ -0.020201340026755776
+    @test r2(m, :Nagelkerke) ≈ 0.24255074155803877
+    @test r2(m, :devianceratio) ≈ 0.375
+
+    @test_throws ArgumentError r2(m, :err)
+    @test_throws MethodError r2(m)
+    @test adjr2(m, :McFadden) ≈ 1.5
+    @test adjr2(m, :devianceratio) ≈ 0.3486842105263158
+    @test_throws ArgumentError adjr2(m, :err)
+
+    @test r2 === r²
+    @test adjr2 === adjr²
+end
+
+end # module TestStatisticalModel


### PR DESCRIPTION
Cover functions for which we provide a fallback definition.
Also turn `ExceptionError` into more specific `ArgumentError`.

Maybe it would also be worth testing that other functions (for which we only provide an empty definition) are defined?