### PR TITLE
Adjust definition of null model when there is no intercept

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsAPI"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 authors = ["Milan Bouchet-Valat <nalimilan@club.fr"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -57,7 +57,11 @@ function islinear end
 """
     nulldeviance(model::StatisticalModel)
 
-Return the deviance of the null model, that is the one including only the intercept.
+Return the deviance of the null model, which is obtained by dropping all
+independent variables present in `model`.
+
+If `model` includes an intercept, the null model is the one with only the intercept;
+otherwise, it is the one without any predictor (not even the intercept).
 """
 function nulldeviance end
 
@@ -81,8 +85,11 @@ function loglikelihood end
 """
     nullloglikelihood(model::StatisticalModel)
 
-Return the log-likelihood of the null model corresponding to `model`.
-This is usually the model containing only the intercept.
+Return the log-likelihood of the null model, which is obtained by dropping all
+independent variables present in `model`.
+
+If `model` includes an intercept, the null model is the one with only the intercept;
+otherwise, it is the one without any predictor (not even the intercept).
 """
 function nullloglikelihood end
 

--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -57,7 +57,7 @@ function islinear end
 """
     nulldeviance(model::StatisticalModel)
 
-Return the deviance of the null model, which is obtained by dropping all
+Return the deviance of the null model, obtained by dropping all
 independent variables present in `model`.
 
 If `model` includes an intercept, the null model is the one with only the intercept;
@@ -85,7 +85,7 @@ function loglikelihood end
 """
     nullloglikelihood(model::StatisticalModel)
 
-Return the log-likelihood of the null model, which is obtained by dropping all
+Return the log-likelihood of the null model, obtained by dropping all
 independent variables present in `model`.
 
 If `model` includes an intercept, the null model is the one with only the intercept;


### PR DESCRIPTION
Technically this is breaking, but the current definition gives negative R² for models without the intercept (https://github.com/JuliaStats/GLM.jl/pull/481).

@Nosferican @jmboehm @lbittarello @crsl4 @getzze @ararslan I saw you define `nulldeviance` and/or `nullloglikelihood` in your modeling packages. What do you think of this change? It would be problematic to change the documentation of the function if packages are not updated to reflect it.

Cc: @palday @mousum-github