### PR TITLE
Add `offset` to get the offset term from a model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsAPI"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 authors = ["Milan Bouchet-Valat <nalimilan@club.fr"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/regressionmodel.jl
+++ b/src/regressionmodel.jl
@@ -109,3 +109,11 @@ function reconstruct end
 In-place version of [`reconstruct`](@ref).
 """
 function reconstruct! end
+
+"""
+    offset(model::RegressionModel)
+
+Return the offset used in the model, i.e. the term added to the linear predictor with
+known coefficient 1.
+"""
+function offset end


### PR DESCRIPTION
Packages like GLM, MixedModels, and (at least theoretically) BetaRegression support offsets for the linear predictor. It would be nice to be able to query that in a unified way. This commit adds a function `offset` that can be extended accordingly. For example, the aforementioned packages could include definitions such as:
```julia
StatsAPI.offset(glm::GeneralizedLinearModel) = glm.rr.offset
StatsAPI.offset(glmm::GeneralizedLinearMixedModel) = glmm.resp.offset
StatsAPI.offset(beta::BetaRegressionModel) = beta.offset
```

I've also bumped the minor version of the package as a separate commit so that a release can be tagged with this feature if it's accepted.