### PR TITLE
Add `linearpredictor` and `linearpredictor!`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/site/
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsAPI"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 authors = ["Milan Bouchet-Valat <nalimilan@club.fr"]
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/regressionmodel.jl
+++ b/src/regressionmodel.jl
@@ -114,7 +114,7 @@ function reconstruct! end
     offset(model::RegressionModel)
 
 Return the offset used in the model, i.e. the term added to the linear predictor with
-known coefficient 1.
+known coefficient 1, or `nothing` if the model was not fit with an offset.
 """
 function offset end
 

--- a/src/regressionmodel.jl
+++ b/src/regressionmodel.jl
@@ -117,3 +117,18 @@ Return the offset used in the model, i.e. the term added to the linear predictor
 known coefficient 1.
 """
 function offset end
+
+"""
+    linearpredictor(model::RegressionModel)
+
+Return the model's linear predictor, `Xβ` where `X` is the model matrix and `β` is the
+vector of coefficients, or `Xβ + offset` if the model was fit with an offset.
+"""
+function linearpredictor end
+
+"""
+    linearpredictor!(storage, model::RegressionModel)
+
+In-place version of [`linearpredictor`](@ref), storing the result in `storage`.
+"""
+function linearpredictor! end


### PR DESCRIPTION
I've added a default definition for `linearpredictor` that requires that a model has implemented `modelmatrix`, `coef`, and `offset`. I did not add a default definition nor documented signature for `linearpredictor!`.

As separate commits, I've also bumped the version to 1.5.0 for a feature release (assuming this is desirable) and ignored Manifest.toml in the .gitignore.