### PR TITLE
add pvalue()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsAPI"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 authors = ["Milan Bouchet-Valat <nalimilan@club.fr"]
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -32,4 +32,11 @@ function pairwise end
 # of the default definition.
 function pairwise! end
 
+"""
+    pvalue(test)
+
+Compute the p-value for a given significance test.
+"""
+function pvalue end
+
 end # module


### PR DESCRIPTION
So that packages that define pvalue() can be used together without qualifying the name.