### PR TITLE
Add an abstract type `HypothesisTest`

### DIFF
--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -36,6 +36,9 @@ function pairwise! end
     HypothesisTest
 
 Abstract supertype for all statistical hypothesis tests.
+Subtypes must implement [`pvalue`](@ref) at a minimum and may also
+implement functions such as [`confint`](@ref), [`nobs`](@ref), and
+[`dof`](@ref) as appropriate.
 """
 abstract type HypothesisTest end
 

--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -32,4 +32,11 @@ function pairwise end
 # of the default definition.
 function pairwise! end
 
+"""
+    HypothesisTest
+
+Abstract supertype for all statistical hypothesis tests.
+"""
+abstract type HypothesisTest end
+
 end # module


### PR DESCRIPTION
This is currently defined in HypothesisTests. Defining the common supertype in this package would allow other packages to define their own hypothesis test types that are too specific and/or have too many dependencies to upstream to HypothesisTests. This could include, for example, the log-rank test for comparing Kaplan-Meier survival curves in Survival and the likelihood ratio test in StatsModels.