### PR TITLE
Add a function for extracting a test statistic

### DIFF
--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -37,8 +37,8 @@ function pairwise! end
 
 Abstract supertype for all statistical hypothesis tests.
 Subtypes must implement [`pvalue`](@ref) at a minimum and may also
-implement functions such as [`confint`](@ref), [`nobs`](@ref), and
-[`dof`](@ref) as appropriate.
+implement functions such as [`teststatistic`](@ref), [`confint`](@ref),
+[`nobs`](@ref), and [`dof`](@ref) as appropriate.
 """
 abstract type HypothesisTest end
 
@@ -48,5 +48,12 @@ abstract type HypothesisTest end
 Compute the p-value for a given significance test.
 """
 function pvalue end
+
+"""
+    teststatistic(test)
+
+Return the test statistic for a given hypothesis test.
+"""
+function teststatistic end
 
 end # module


### PR DESCRIPTION
This is added to StatsAPI rather than to HypothesisTests since StatsAPI also houses `HypothesisTest`, `pvalue`, and other relevant functionality.

Defining this function will bring a resolution to the 7-year-old issue https://github.com/JuliaStats/HypothesisTests.jl/issues/79, which has received a number of duplicates over the years, suggesting that it would be of general interest.

I considered the name `statistic`, and still rather prefer that (`teststatistic` has too many s's and t's 😩), but wasn't sure whether it was insufficiently descriptive. I'd be interested in hearing thoughts both on naming and on whether this should be required for `HypothesisTest` as `pvalue` is or whether it should be optional (what I have currently).