### PR TITLE
Fix typo in doc strings for r2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsAPI"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 authors = ["Milan Bouchet-Valat <nalimilan@club.fr"]
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -290,7 +290,7 @@ adjr2(model::StatisticalModel)
 
 Adjusted pseudo-coefficient of determination (adjusted pseudo R-squared).
 For nonlinear models, one of the several pseudo R² definitions must be chosen via `variant`.
-The only currently supported variants are `:MacFadden`, defined as ``1 - (\\log (L) - k)/\\log (L0)`` and
+The only currently supported variants are `:McFadden`, defined as ``1 - (\\log (L) - k)/\\log (L0)`` and
 `:devianceratio`, defined as ``1 - (D/(n-k))/(D_0/(n-1))``.
 In these formulas, ``L`` is the likelihood of the model, ``L0`` that of the null model
 (the model including only the intercept), ``D`` is the deviance of the model,

--- a/src/statisticalmodel.jl
+++ b/src/statisticalmodel.jl
@@ -233,7 +233,7 @@ Pseudo-coefficient of determination (pseudo R-squared).
 
 For nonlinear models, one of several pseudo R² definitions must be chosen via `variant`.
 Supported variants are:
-- `:MacFadden` (a.k.a. likelihood ratio index), defined as ``1 - \\log (L)/\\log (L_0)``;
+- `:McFadden` (a.k.a. likelihood ratio index), defined as ``1 - \\log (L)/\\log (L_0)``;
 - `:CoxSnell`, defined as ``1 - (L_0/L)^{2/n}``;
 - `:Nagelkerke`, defined as ``(1 - (L_0/L)^{2/n})/(1 - L_0^{2/n})``.
 - `:devianceratio`, defined as ``1 - D/D_0``.


### PR DESCRIPTION
Variant is `:MacFadden` in the docs, but `:McFadden` in the if else branch. Googling / Wikipedia confirms that "McFadden" is correct