### PR TITLE
Declare StatsAPI functionality as `public` on Julia >= 1.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatsAPI"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 authors = ["Milan Bouchet-Valat <nalimilan@club.fr"]
-version = "1.7.1"
+version = "1.8.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/StatsAPI.jl
+++ b/src/StatsAPI.jl
@@ -1,6 +1,71 @@
 module StatsAPI
 
-using LinearAlgebra
+using LinearAlgebra: Symmetric, diag
+
+# https://github.com/JuliaLang/julia/pull/50105
+@static if VERSION >= v"1.11.0-DEV.469"
+    # statisticalmodel.jl
+    eval(Expr(
+        :public,
+        :StatisticalModel,
+        :coef,
+        :coefnames,
+        :coeftable,
+        :confint,
+        :deviance,
+        :islinear,
+        :nulldeviance,
+        :loglikelihood,
+        :nullloglikelihood,
+        :score,
+        :nobs,
+        :dof,
+        :mss,
+        :rss,
+        :informationmatrix,
+        :stderror,
+        :vcov,
+        :weights,
+        :isfitted,
+        :fit,
+        :fit!,
+        :aic,
+        :aicc,
+        :bic,
+        :r2,
+        :r²,
+        :adjr2,
+        :adjr²,
+    ))
+
+    # regressionmodel.jl
+    eval(Expr(
+        :public,
+        :RegressionModel,
+        :fitted,
+        :response,
+        :responsename,
+        :meanresponse,
+        :modelmatrix,
+        :crossmodelmatrix,
+        :leverage,
+        :cooksdistance,
+        :residuals,
+        :predict,
+        :predict!,
+        :dof_residual,
+        :reconstruct,
+        :reconstruct!,
+        :offset,
+        :linearpredictor,
+        :linearpredictor!,
+        :vif,
+        :gvif,
+    ))
+
+    # StatsAPI.jl
+    eval(Expr(:public, :params, :params!, :pairwise, :pairwise!, :HypothesisTest, :pvalue))
+end
 
 include("statisticalmodel.jl")
 include("regressionmodel.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,25 @@ using Test, StatsAPI
 
 @testset "StatsAPI" begin
 
+# Check that all names in StatsAPI are public
+if isdefined(Base, :ispublic)
+    names_statsapi = names(StatsAPI; all = true)
+    filter!(names_statsapi) do name
+        if name == :eval || name == :include
+            # Ignore `eval` and `include` (available in every `module`)
+            return false
+        elseif startswith(string(name), "#")
+            # Ignore names of the form `#xyz...`
+            return false
+        else
+            return true
+        end
+    end
+    @testset "public: $(name)" for name in names_statsapi
+        @test Base.ispublic(StatsAPI, name)
+    end
+end
+
 include("regressionmodel.jl")
 include("statisticalmodel.jl")
 


### PR DESCRIPTION
When adding tests with ExplicitImports in a downstream package, tests failed because the StatsAPI API is currently not declared as `public`.

This PR declares all functionality in StatsAPI as `public` on Julia >= 1.11 and adds tests for it.